### PR TITLE
fix: Switch to Mistral-7B model for improved reliability

### DIFF
--- a/compliance_agent/config.py
+++ b/compliance_agent/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     # LLM configuration
     # The path is relative to the `compliance_agent` directory.
     llm_model_path: Optional[str] = Field(
-        default="models/llama-2-7b-chat.Q4_K_M.gguf",
+        default="models/mistral-7b-instruct-v0.1.Q4_K_M.gguf",
         env="LLM_MODEL_PATH"
     )
 

--- a/compliance_agent/setup_model.py
+++ b/compliance_agent/setup_model.py
@@ -41,15 +41,15 @@ def download_file(url, folder_name, file_name):
 
 if __name__ == "__main__":
     # URL of the GGUF model to download.
-    # Using the public Llama-2-7B-Chat model.
-    model_url = "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_K_M.gguf"
+    # Using the reliable Mistral-7B-Instruct model.
+    model_url = "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf"
 
     # Directory to save the model inside the compliance_agent directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
     models_dir = os.path.join(script_dir, 'models')
 
     # Filename for the downloaded model
-    model_name = "llama-2-7b-chat.Q4_K_M.gguf"
+    model_name = "mistral-7b-instruct-v0.1.Q4_K_M.gguf"
 
     print("Starting model download...")
     download_file(model_url, models_dir, model_name)


### PR DESCRIPTION
This commit resolves the issue of inconsistent and empty narratives by switching the default LLM from Llama-2-7B to the more capable and reliable Mistral-7B-Instruct-v0.1 model. This model is better suited for instruction-following tasks and provides more consistent and higher-quality output.

The following files have been updated:
- `setup_model.py`: Changed to download the Mistral-7B model.
- `config.py`: Updated to set the new model as the default.

All previous stability improvements (low temperature, top_p, and retry logic) have been kept in place to ensure maximum reliability.