### PR TITLE
fix: Switch to public models to resolve download error

### DIFF
--- a/compliance_agent/config.py
+++ b/compliance_agent/config.py
@@ -27,9 +27,9 @@ class Settings(BaseSettings):
                 "url": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf"
             },
             {
-                "name": "Phi-3-mini-4k-instruct",
-                "path": "models/Phi-3-mini-4k-instruct-q4.gguf",
-                "url": "https://huggingface.co/TheBloke/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-q4.gguf"
+                "name": "OpenHermes-2.5-Mistral-7B",
+                "path": "models/openhermes-2.5-mistral-7b.Q4_K_M.gguf",
+                "url": "https://huggingface.co/TheBloke/OpenHermes-2.5-Mistral-7B-GGUF/resolve/main/openhermes-2.5-mistral-7b.Q4_K_M.gguf"
             }
         ],
         env="LLM_MODELS"


### PR DESCRIPTION
This commit resolves a persistent `401 Unauthorized` error by replacing all restricted models with publicly accessible alternatives.

The `config.py` has been updated to use the following models:
- `Mistral-7B-Instruct-v0.1`
- `OpenHermes-2.5-Mistral-7B`

Both of these models are high-quality and do not require user authentication to download. This change ensures that the `setup_model.py` script will run successfully for all users without any manual intervention or Hugging Face account.