### PR TITLE
feat(spire): Implement Phase 1 of Unified Identity

### DIFF
--- a/hybrid-cloud-poc/code-rollout-phase-1/README.md
+++ b/hybrid-cloud-poc/code-rollout-phase-1/README.md
@@ -4,9 +4,9 @@ This phase introduces the initial implementation of the "Unified Identity" featu
 
 ## Summary of Changes
 
-This phase introduces a new RPC, `PerformSovereignAttestation`, to the Workload API. This RPC is used to perform a sovereign attestation flow, which is a process of verifying the identity of a workload in a sovereign cloud environment.
+This phase introduces a new RPC, `PerformSovereignAttestation`, to the Workload API, and a new `sovereign` node attestor plugin to the SPIRE server. These additions are used to perform a sovereign attestation flow, which is a process of verifying the identity of a workload in a sovereign cloud environment.
 
-The `PerformSovereignAttestation` RPC is feature-flagged using the `unified_identity` build tag. When this build tag is enabled, the RPC is handled by a stubbed implementation that returns a canned response. When the build tag is not present, the RPC returns an "unimplemented" error.
+The `PerformSovereignAttestation` RPC and the `sovereign` node attestor are feature-flagged using the `unified_identity` build tag. When this build tag is enabled, the RPC is handled by a stubbed implementation that returns a canned response, and the node attestor returns a stubbed agent ID. When the build tag is not present, the RPC returns an "unimplemented" error, and the node attestor is not available.
 
 ### Prerequisites
 
@@ -17,9 +17,10 @@ To build and run the code in this phase, you will need to have the following ins
 
 ### Compilation - how to turn on feature flag
 
-To enable the "Unified Identity" feature, you will need to build the SPIRE agent with the `unified_identity` build tag. You can do this by running the following command:
+To enable the "Unified Identity" feature, you will need to build the SPIRE server and agent with the `unified_identity` build tag. You can do this by running the following commands:
 
 ```
+go build -tags unified_identity ./cmd/spire-server
 go build -tags unified_identity ./cmd/spire-agent
 ```
 
@@ -34,7 +35,11 @@ This phase adds unit tests for the `PerformSovereignAttestation` RPC. The tests 
 
 ### End-to-End Test
 
-There are no end-to-end tests in this phase. End-to-end tests will be added in a future phase.
+This phase adds an end-to-end test for the sovereign attestation flow. The test is located in the `test/integration/suites/sovereign-attestation` directory. To run the test, run the following command from the `test/integration` directory:
+
+```
+./test.sh suites/sovereign-attestation
+```
 
 ### Current Tests - Backward compatibility
 

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/.gitignore
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build artifacts
+spire-server
+spire-agent

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor.go
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor.go
@@ -33,7 +33,7 @@ func (repo *nodeAttestorRepository) Versions() []catalog.Version {
 }
 
 func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
-	return []catalog.BuiltIn{
+	builtIns := []catalog.BuiltIn{
 		awsiid.BuiltIn(),
 		azuremsi.BuiltIn(),
 		gcpiit.BuiltIn(),
@@ -44,6 +44,7 @@ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
 		tpmdevid.BuiltIn(),
 		x509pop.BuiltIn(),
 	}
+	return appendBuiltIns(builtIns)
 }
 
 type nodeAttestorV1 struct{}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor_stub.go
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor_stub.go
@@ -1,0 +1,11 @@
+//go:build !unified_identity
+
+package catalog
+
+import (
+	"github.com/spiffe/spire/pkg/common/catalog"
+)
+
+func appendBuiltIns(builtIns []catalog.BuiltIn) []catalog.BuiltIn {
+	return builtIns
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor_unified_identity.go
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/catalog/nodeattestor_unified_identity.go
@@ -1,0 +1,12 @@
+//go:build unified_identity
+
+package catalog
+
+import (
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/sovereign"
+)
+
+func appendBuiltIns(builtIns []catalog.BuiltIn) []catalog.BuiltIn {
+	return append(builtIns, sovereign.BuiltIn())
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/plugin/nodeattestor/sovereign/sovereign.go
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/pkg/server/plugin/nodeattestor/sovereign/sovereign.go
@@ -1,0 +1,70 @@
+//go:build unified_identity
+
+package sovereign
+
+import (
+	"context"
+
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	pluginName = "sovereign"
+)
+
+// Unified-Identity - Phase 1: SPIRE API & Policy Staging (Stubbed Keylime)
+func BuiltIn() catalog.BuiltIn {
+	return builtin(New())
+}
+
+func builtin(p *Plugin) catalog.BuiltIn {
+	return catalog.MakeBuiltIn(pluginName,
+		nodeattestorv1.NodeAttestorPluginServer(p),
+		configv1.ConfigServiceServer(p),
+	)
+}
+
+type Plugin struct {
+	nodeattestorv1.UnsafeNodeAttestorServer
+	configv1.UnsafeConfigServer
+}
+
+func New() *Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	payload := req.GetPayload()
+	if len(payload) == 0 {
+		return status.Error(codes.InvalidArgument, "missing attestation data")
+	}
+
+	// In Phase 1, we are just stubbing this out.
+	// We will return a canned response.
+	return stream.Send(&nodeattestorv1.AttestResponse{
+		Response: &nodeattestorv1.AttestResponse_AgentAttributes{
+			AgentAttributes: &nodeattestorv1.AgentAttributes{
+				SpiffeId: "spiffe://domain.test/spire/agent/sovereign/stubbed-agent",
+			},
+		},
+	})
+}
+
+func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
+	return &configv1.ConfigureResponse{}, nil
+}
+
+func (p *Plugin) Validate(ctx context.Context, req *configv1.ValidateRequest) (*configv1.ValidateResponse, error) {
+	return &configv1.ValidateResponse{
+		Valid: true,
+	}, nil
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/common
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/common
@@ -7,7 +7,7 @@ yellow=$(tput setaf 3) || true
 bold=$(tput bold) || true
 
 timestamp() {
-    date -u "+[%Y-%m-%dT%H:%M:%SZ]"
+    /bin/date -u "+[%Y-%m-%dT%H:%M:%SZ]"
 }
 
 log-info() {

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/setup/sovereign-attestation/main.go
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/setup/sovereign-attestation/main.go
@@ -1,0 +1,46 @@
+//go:build unified_identity
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := workloadapi.New(ctx)
+	if err != nil {
+		log.Fatalf("Unable to create workload API client: %v", err)
+	}
+	defer client.Close()
+
+	stream, err := client.PerformSovereignAttestation(ctx, &workload.PerformSovereignAttestationRequest{
+		AttestationData: []byte("stubbed-attestation-data"),
+	})
+	if err != nil {
+		log.Fatalf("Unable to perform sovereign attestation: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		log.Fatalf("Unable to receive sovereign attestation response: %v", err)
+	}
+
+	if string(resp.Challenge) != "stubbed-challenge" {
+		log.Fatalf("Unexpected challenge: %s", resp.Challenge)
+	}
+
+	if resp.Metadata["provider"] != "stubbed-keylime" {
+		log.Fatalf("Unexpected metadata: %v", resp.Metadata)
+	}
+
+	fmt.Println("Successfully performed sovereign attestation")
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/01-test-sovereign-attestation
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/01-test-sovereign-attestation
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# build the server and agent with the unified_identity tag
+go build -tags unified_identity -o ../../../bin/spire-server ../../../cmd/spire-server
+go build -tags unified_identity -o ../../../bin/spire-agent ../../../cmd/spire-agent
+
+# build the client
+go build -tags unified_identity -o ../../../bin/sovereign-attestation ../setup/sovereign-attestation
+
+# start the server
+../../../bin/spire-server run -config conf/server.conf &
+
+# wait for the server to be ready
+sleep 5
+
+# start the agent
+../../../bin/spire-agent run -config conf/agent.conf &
+
+# wait for the agent to be ready
+sleep 5
+
+# run the client
+../../../bin/sovereign-attestation
+
+# stop the agent
+kill %2
+
+# stop the server
+kill %1

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/conf/agent.conf
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/conf/agent.conf
@@ -1,0 +1,19 @@
+agent {
+    data_dir = "./.data"
+    log_level = "DEBUG"
+    server_address = "127.0.0.1"
+    server_port = 8081
+    trust_domain = "domain.test"
+    trust_bundle_path = "./.data/bundle.crt"
+}
+
+plugins {
+    NodeAttestor "sovereign" {
+        plugin_data {
+        }
+    }
+    KeyManager "memory" {
+        plugin_data {
+        }
+    }
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/conf/server.conf
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/conf/server.conf
@@ -1,0 +1,24 @@
+server {
+    bind_address = "127.0.0.1"
+    bind_port = 8081
+    trust_domain = "domain.test"
+    data_dir = "./.data"
+    log_level = "DEBUG"
+}
+
+plugins {
+    NodeAttestor "sovereign" {
+        plugin_data {
+        }
+    }
+    KeyManager "memory" {
+        plugin_data {
+        }
+    }
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "./.data/datastore.sqlite3"
+        }
+    }
+}

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/run.sh
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# build the server and agent with the unified_identity tag
+go build -tags unified_identity -o ../../../bin/spire-server ../../../cmd/spire-server
+go build -tags unified_identity -o ../../../bin/spire-agent ../../../cmd/spire-agent
+
+# build the client
+go build -tags unified_identity -o ../../../bin/sovereign-attestation ../setup/sovereign-attestation
+
+# start the server
+../../../bin/spire-server run -config conf/server.conf &
+
+# wait for the server to be ready
+sleep 5
+
+# start the agent
+../../../bin/spire-agent run -config conf/agent.conf &
+
+# wait for the agent to be ready
+sleep 5
+
+# run the client
+../../../bin/sovereign-attestation
+
+# stop the agent
+kill %2
+
+# stop the server
+kill %1

--- a/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/teardown.sh
+++ b/hybrid-cloud-poc/code-rollout-phase-1/spire/test/integration/suites/sovereign-attestation/teardown.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+rm -f ../../../bin/spire-server
+rm -f ../../../bin/spire-agent
+rm -f ../../../bin/sovereign-attestation
+rm -rf ./.data


### PR DESCRIPTION
This commit introduces the initial implementation of the "Unified Identity" feature, focusing on the SPIRE API and policy staging with a stubbed Keylime verifier.

The main changes in this commit are:

- A new RPC, `PerformSovereignAttestation`, has been added to the Workload API. This RPC is used to perform a sovereign attestation flow.
- A new `sovereign` node attestor plugin has been added to the SPIRE server.
- The `PerformSovereignAttestation` RPC and the `sovereign` node attestor are feature-flagged using the `unified_identity` build tag.
- The `go-spiffe`, `spire`, and `spire-api-sdk` modules have been updated to support the new RPC.
- Unit tests have been added for the `PerformSovereignAttestation` RPC.
- An end-to-end test has been added for the sovereign attestation flow, but it is not yet working.
- The `README.md` file has been updated to document the new feature.